### PR TITLE
Add ability to pass options to WebRTC hook (#3)

### DIFF
--- a/src/feature/provider/hook/useWebRtc.spec.tsx
+++ b/src/feature/provider/hook/useWebRtc.spec.tsx
@@ -1,6 +1,13 @@
+/* eslint-env jest */
 import { renderHook } from '@testing-library/react-hooks'
 
 import React from 'react'
+import * as Y from 'yjs'
+
+jest.mock('y-webrtc', () => ({
+  WebrtcProvider: jest.fn()
+}))
+/* eslint-disable import/first */
 import { WebrtcProvider } from 'y-webrtc'
 
 import { useWebRtc } from './useWebRtc'
@@ -58,5 +65,29 @@ describe('useWebRtc', () => {
     }).not.toThrowError(
       'Error: A Yjs Doc connected to room "room" already exists!'
     )
+  })
+
+  it('Passes password option to WebrtcProvider.', () => {
+    jest.resetAllMocks()
+
+    const doc = new Y.Doc()
+
+    renderHook(
+      () => useWebRtc('room', {
+        password: 'password'
+      }),
+      {
+        wrapper: ({ children }) =>
+          (
+            <DocumentProvider doc={doc}>
+              {children}
+            </DocumentProvider>
+          )
+      }
+    )
+
+    expect(WebrtcProvider).toBeCalledWith('room', doc, {
+      password: 'password'
+    })
   })
 })

--- a/src/feature/provider/hook/useWebRtc.ts
+++ b/src/feature/provider/hook/useWebRtc.ts
@@ -2,8 +2,19 @@ import React from 'react'
 import { WebrtcProvider } from 'y-webrtc'
 
 import { useDoc, useProviders } from '@/feature/doc'
+import { Awareness } from 'y-protocols/awareness'
 
-export const useWebRtc = (room: string): WebrtcProvider => {
+export const useWebRtc = (
+  room: string,
+  options: {
+    signaling?: string[]
+    password?: string
+    awareness?: Awareness
+    maxConns?: number
+    filterBcConns?: boolean
+    peerOpts?: any
+  } = {}
+): WebrtcProvider => {
   const doc = useDoc()
   const providers = useProviders()
 
@@ -15,7 +26,18 @@ export const useWebRtc = (room: string): WebrtcProvider => {
       if (existingProvider !== undefined) {
         return existingProvider
       } else {
-        const provider = new WebrtcProvider(room, doc)
+        const provider = new WebrtcProvider(
+          room,
+          doc,
+          options as {
+            signaling: string[]
+            password: string | null
+            awareness: Awareness
+            maxConns: number
+            filterBcConns: boolean
+            peerOpts: any
+          }
+        )
 
         if (!(providers.has(WebrtcProvider))) {
           providers.set(WebrtcProvider, new Map())


### PR DESCRIPTION
Solves #3 by allowing the passing of the full options object to the WebrtcProvider class.